### PR TITLE
Add Playwright test for Client Work visibility

### DIFF
--- a/tests/test-epam-scenario.spec.ts
+++ b/tests/test-epam-scenario.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('Verify Client Work visibility on EPAM website', async ({ page }) => {
+  // Navigate to the EPAM website
+  await page.goto('https://www.epam.com/');
+
+  // Select "Services" from the header menu
+  await page.click('header >> text=Services');
+
+  // Click the "Explore Our Client Work" link
+  await page.click('text=Explore Our Client Work');
+
+  // Verify that the "Client Work" text is visible on the page
+  const clientWorkText = await page.locator('text=Client Work');
+  await expect(clientWorkText).toBeVisible();
+});


### PR DESCRIPTION
This pull request adds a Playwright test scenario to verify the visibility of the 'Client Work' text on the EPAM website.

Test Scenario:
1. Navigate to https://www.epam.com/
2. Select 'Services' from the header menu.
3. Click the 'Explore Our Client Work' link.
4. Verify that the 'Client Work' text is visible on the page.