### PR TITLE
Add Playwright test scenario for EPAM Client Work

### DIFF
--- a/tests/epam-client-work.spec.ts
+++ b/tests/epam-client-work.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+// Test scenario: Navigate to https://www.epam.com/
+test('Navigate to EPAM and verify Client Work', async ({ page }) => {
+  // Navigate to the EPAM website
+  await page.goto('https://www.epam.com/');
+
+  // Select "Services" from the header menu
+  await page.click('text=Services');
+
+  // Click the "Explore Our Client Work" link
+  await page.click('text=Explore Our Client Work');
+
+  // Verify that the "Client Work" text is visible on the page
+  const clientWorkText = await page.isVisible('text=Client Work');
+  expect(clientWorkText).toBeTruthy();
+
+  // Capture screenshot of the final state
+  await page.screenshot({ path: 'screenshots/client-work-page.png' });
+});


### PR DESCRIPTION
This pull request includes a Playwright test scenario that navigates to the EPAM website, selects 'Services' from the header menu, clicks the 'Explore Our Client Work' link, and verifies that the 'Client Work' text is visible on the page. Screenshots of the test execution are also included.