### PR TITLE
Add Playwright Test Scenario for EPAM Client Work Verification

### DIFF
--- a/screenshots/client-work-verification.png
+++ b/screenshots/client-work-verification.png
@@ -1,0 +1,1 @@
+<base64-encoded-image-content>

--- a/screenshots/client-work.png
+++ b/screenshots/client-work.png
@@ -1,0 +1,1 @@
+<base64-encoded-image-content>

--- a/screenshots/homepage.png
+++ b/screenshots/homepage.png
@@ -1,0 +1,1 @@
+<base64-encoded-image-content>

--- a/screenshots/services.png
+++ b/screenshots/services.png
@@ -1,0 +1,1 @@
+<base64-encoded-image-content>

--- a/tests/epam-client-work.spec.ts
+++ b/tests/epam-client-work.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test('EPAM Client Work Verification', async ({ page }) => {
+  // Navigate to https://www.epam.com/
+  await page.goto('https://www.epam.com/');
+  await page.screenshot({ path: 'screenshots/homepage.png' });
+
+  // Select "Services" from the header menu
+  await page.click('text=Services');
+  await page.screenshot({ path: 'screenshots/services.png' });
+
+  // Click the "Explore Our Client Work" link
+  await page.click('text=Explore Our Client Work');
+  await page.screenshot({ path: 'screenshots/client-work.png' });
+
+  // Verify that the "Client Work" text is visible on the page
+  const clientWorkText = await page.textContent('h1');
+  expect(clientWorkText).toContain('Client Work');
+  await page.screenshot({ path: 'screenshots/client-work-verification.png' });
+});


### PR DESCRIPTION
This pull request adds a Playwright test scenario to verify the 'Client Work' section on the EPAM website.

### Test Scenario
1. Navigate to https://www.epam.com/
2. Select 'Services' from the header menu.
3. Click the 'Explore Our Client Work' link.
4. Verify that the 'Client Work' text is visible on the page.

### Files Added
- `tests/epam-client-work.spec.ts`
- `screenshots/homepage.png`
- `screenshots/services.png`
- `screenshots/client-work.png`
- `screenshots/client-work-verification.png`